### PR TITLE
Add .travis.yml for enabling continuous integration and fix Java version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: java
+jdk: openjdk8
+
+branches:
+  only: [ "master" ]
+
+addons:
+  apt:
+    packages:
+      - cmake
+      - automake
+      - nasm
+      - build-essential
+      - autoconf
+      - libtool
+      - libglib2.0-dev
+      - libexpat1-dev
+      - gtk-doc-tools
+      - gobject-introspection
+      - zlib1g-dev
+
+matrix:
+  fast_finish: true
+
+  include:
+      - name: "JVips Linux target"
+        os: linux
+        sudo: required
+        dist: xenial
+        compiler: gcc
+        script:
+          - ./build.sh --without-w64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.6.0)
 
 find_package(PkgConfig REQUIRED)
 
-find_package(Java REQUIRED)
+find_package(Java 1.8 REQUIRED)
 include(UseJava)
 
 set(JVIPS_VERSION 1.0.0)

--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,10 @@ export BUILDDIR=${BASEDIR}/build
 # For Fedora / CentOS
 CMAKE_BIN=cmake3
 
+if ! [ -x "$(command -v cmake3)" ]; then
+    CMAKE_BIN=cmake
+fi
+
 (
 ##########################
 ###### Build Win64 #######

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -140,7 +140,7 @@ wget -nv -nc "https://github.com/libvips/libvips/archive/v${VIPS_VERSION}.tar.gz
 mkdir -p "${CHECKOUT}/libvips-${VIPS_VERSION}-${TARGET}"
 tar zxf "v${VIPS_VERSION}.tar.gz" -C "${CHECKOUT}/libvips-${VIPS_VERSION}-${TARGET}" --strip-components=1
 pushd "${CHECKOUT}/libvips-${VIPS_VERSION}-${TARGET}"
-./autogen.sh ${HOST}
+./autogen.sh ${HOST} -version
 ./configure \
      CFLAGS="${CFLAGS}" \
      CXXFLAGS="${CXXFLAGS}" \
@@ -150,8 +150,8 @@ pushd "${CHECKOUT}/libvips-${VIPS_VERSION}-${TARGET}"
      --enable-shared --disable-static \
      --with-jpeg-includes=$PREFIX/include \
      --with-jpeg-libraries=$PREFIX/lib \
-     --with-png-includes=$PREFIX/include \
-     --with-png-libraries=$PREFIX/lib \
+     PNG_CFLAGS="-I$PREFIX/include/ -I$PREFIX/include/libpng16/" \
+     PNG_LIBS="-L$PREFIX/lib/ -lpng16" \
      --with-giflib-includes=$PREFIX/include \
      --with-giflib-libraries=$PREFIX/lib \
      --with-libwebp \
@@ -165,6 +165,7 @@ pushd "${CHECKOUT}/libvips-${VIPS_VERSION}-${TARGET}"
      --without-magick \
      --without-orc \
      --without-gsf \
+     --without-rsvg \
      --prefix="$PREFIX"
 make -j ${JOBS}
 make install

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.5</version>
                 <configuration>
-                    <source>7</source>
-                    <target>7</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -47,7 +47,6 @@
                     <include>libpng16.so</include>
                     <include>libjpeg.so</include>
                     <include>libturbojpeg.so</include>
-                    <include>liborc-0.4.so</include>
                     <include>libgif.so</include>
                     <include>libwebp.so</include>
                     <include>libwebpmux.so</include>
@@ -69,12 +68,17 @@
                 </includes>
             </resource>
         </resources>
+        <testResources>
+            <testResource>
+                <directory>${project.basedir}/src/test/resources/</directory>
+            </testResource>
+        </testResources>
     </build>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>RELEASE</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
* Update libvips build for avoiding libpng link problem:
  "built with libpng-1.2.54 but running with ..."
* Add test resources directory to pom.xml
* Fix Java version in pom.xml and cmake
* Fix junit version in pom.xml