### PR TITLE
Fix dist tarball name

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -117,6 +117,6 @@ mvn ${MAVEN_ARGS} clean install
 
 if [ ${DIST} -gt 0 ]; then
     if [ ${BUILD_LINUX} -gt 0 ]; then
-       tar -cvf "JVips-${TARGET}.tar.gz" JVips.jar -C ${BUILDDIR}/${TARGET}/inst/ bin lib include share
+       tar -cvf "JVips-linux.tar.gz" JVips.jar -C ${BUILDDIR}/linux/inst/ bin lib include share
     fi
 fi


### PR DESCRIPTION
Tarball name may be JVips-w64.tar.gz if all targets are built.
For the moment, only linux dist archive is available.