### PR TITLE
Make getInterpretation call imageGetInterpretation & remove getInterpretationNative

### DIFF
--- a/src/main/c/VipsImage.c
+++ b/src/main/c/VipsImage.c
@@ -373,13 +373,6 @@ Java_com_criteo_vips_VipsImageImpl_hasAlpha(JNIEnv *env, jobject obj)
     return vips_image_hasalpha(im);
 }
 
-JNIEXPORT jint JNICALL
-Java_com_criteo_vips_VipsImageImpl_getInterpretationNative(JNIEnv *env, jobject obj)
-{
-    VipsImage *im = (VipsImage *) (*env)->GetLongField(env, obj, handle_fid);
-    return vips_image_guess_interpretation(im);
-}
-
 JNIEXPORT void JNICALL
 Java_com_criteo_vips_VipsImageImpl_convertTosRGB(JNIEnv *env, jobject obj)
 {

--- a/src/main/c/VipsImage.h
+++ b/src/main/c/VipsImage.h
@@ -193,14 +193,6 @@ JNIEXPORT jboolean JNICALL Java_com_criteo_vips_VipsImageImpl_hasAlpha
 
 /*
  * Class:     com_criteo_vips_VipsImageImpl
- * Method:    getInterpretationNative
- * Signature: ()I
- */
-JNIEXPORT jint JNICALL Java_com_criteo_vips_VipsImageImpl_getInterpretationNative
-  (JNIEnv *, jobject);
-
-/*
- * Class:     com_criteo_vips_VipsImageImpl
  * Method:    convertTosRGB
  * Signature: ()V
  */

--- a/src/main/java/com/criteo/vips/VipsImageImpl.java
+++ b/src/main/java/com/criteo/vips/VipsImageImpl.java
@@ -205,11 +205,13 @@ public class VipsImageImpl extends Vips implements VipsImage {
 
     public native boolean hasAlpha();
 
-    private native int getInterpretationNative();
-
     public VipsInterpretation getInterpretation() {
-        int interpretation = getInterpretationNative();
-        return VipsInterpretation.valueOf(interpretation);
+        /**
+         * The name of the function in libvips is vips_image_get_interpretation
+         * so the Java method should be called imageGetInterpretation.  Just
+         * the correctly named function here.
+        */
+        return imageGetInterpretation();
     }
 
     public native void convertTosRGB() throws VipsException;


### PR DESCRIPTION
getInterpretation should have been called imageGetInterpretation
(which was created independently). Make getInterpretation just call
imageGetInterpretation and remove getInterpretationNative.