### PR TITLE
Bind vips_linear to linear(double[] a, double[] b, boolean uchar)

### DIFF
--- a/src/main/c/VipsImage.c
+++ b/src/main/c/VipsImage.c
@@ -509,3 +509,31 @@ Java_com_criteo_vips_VipsImageImpl_getPoint(JNIEnv *env, jobject image_obj, jint
     g_free(vector);
     return ret;
 }
+
+JNIEXPORT void
+JNICALL Java_com_criteo_vips_VipsImageImpl_linearNative(JNIEnv *env, jobject image_obj, jdoubleArray a, jdoubleArray b, jboolean uchar)
+{
+    jint length = (*env)->GetArrayLength(env, a);
+
+    if ((*env)->GetArrayLength(env, b) != length)
+        throwVipsException(env, "vips_linear requires arrays of the same length");
+    else
+    {
+        VipsImage *im = (VipsImage *) (*env)->GetLongField(env, image_obj, handle_fid);
+        VipsImage *out = NULL;
+        jdouble *a_values = (*env)->GetDoubleArrayElements(env, a, 0);
+        jdouble *b_values = (*env)->GetDoubleArrayElements(env, b, 0);
+
+        int errcode = vips_linear(im, &out, a_values, b_values, length, "uchar", uchar, NULL);
+        (*env)->ReleaseDoubleArrayElements(env, a, a_values, 0);
+        (*env)->ReleaseDoubleArrayElements(env, b, b_values, 0);
+
+        if (errcode)
+            throwVipsException(env, "vips_linear failed");
+        else
+        {
+            (*env)->SetLongField(env, image_obj, handle_fid, (jlong) out);
+            g_object_unref(im);
+        }
+    }
+}

--- a/src/main/c/VipsImage.h
+++ b/src/main/c/VipsImage.h
@@ -217,6 +217,14 @@ JNIEXPORT jboolean JNICALL Java_com_criteo_vips_VipsImageImpl_hasAlpha
 
 /*
  * Class:     com_criteo_vips_VipsImageImpl
+ * Method:    linearNative
+ * Signature: ([D[DZ)V
+ */
+JNIEXPORT void JNICALL Java_com_criteo_vips_VipsImageImpl_linearNative
+  (JNIEnv *, jobject, jdoubleArray, jdoubleArray, jboolean);
+
+/*
+ * Class:     com_criteo_vips_VipsImageImpl
  * Method:    convertTosRGB
  * Signature: ()V
  */

--- a/src/main/java/com/criteo/vips/VipsImage.java
+++ b/src/main/java/com/criteo/vips/VipsImage.java
@@ -19,6 +19,24 @@ package com.criteo.vips;
 import java.awt.*;
 
 public interface VipsImage {
+    /** Pass image through a linear transform, ie. (@out = @in * @a + @b)
+     *
+     * @param a: (array length=n): array of constants for multiplication
+     * @param b: (array length=b.length): array of constants for addition
+     * @param uchar: output uchar pixels if true
+     * @throws VipsException
+     *
+     */
+    void linear(double[] a, double[] b, boolean uchar) throws VipsException;
+
+    /** Pass image through a linear transform, ie. (@out = @in * @a + @b)
+     *
+     * @param a: (array length=n): array of constants for multiplication
+     * @param b: (array length=b.length): array of constants for addition
+     * @throws VipsException
+     *
+     */
+    void linear(double[] a, double[] b) throws VipsException;
 
     /** Read a single pixel from an image.
      *

--- a/src/main/java/com/criteo/vips/VipsImageImpl.java
+++ b/src/main/java/com/criteo/vips/VipsImageImpl.java
@@ -222,6 +222,16 @@ public class VipsImageImpl extends Vips implements VipsImage {
 
     public native boolean hasAlpha();
 
+    public void linear(double[] a, double[] b, boolean uchar) throws VipsException {
+        linearNative(a, b, uchar);
+    }
+
+    private native void linearNative(double[] a, double[] b, boolean uchar) throws VipsException;
+
+    public void linear(double[] a, double[] b) throws VipsException {
+        linear(a, b, false);
+    }
+
     public VipsInterpretation getInterpretation() {
         /**
          * The name of the function in libvips is vips_image_get_interpretation

--- a/src/test/java/com/criteo/vips/VipsImageImplTest.java
+++ b/src/test/java/com/criteo/vips/VipsImageImplTest.java
@@ -724,4 +724,45 @@ public class VipsImageImplTest {
         assertTrue(Arrays.equals(expected, point));
         img.release();
     }
+
+    @Test
+    public void TestGetPointLinear() throws IOException, VipsException {
+        ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
+        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
+        int x = 39;
+        int y = 43;
+
+        assertTrue(Arrays.equals(new double[] { 5.0, 81.0, 218.0 }, img.getPoint(x, y)));
+        img.linear(new double[] {3.2, 1.0, 5}, new double[] {4.3, 1.2, 6.7});
+        assertTrue(Arrays.equals(new double[] { 20.299999237060547, 82.19999694824219, 1096.699951171875 }, img.getPoint(x, y)));
+        img.release();
+    }
+
+    @Test
+    public void TestGetPointLinearUchar() throws IOException, VipsException {
+        ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
+        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
+        int x = 39;
+        int y = 43;
+
+        assertTrue(Arrays.equals(new double[] { 5.0, 81.0, 218.0 }, img.getPoint(x, y)));
+        img.linear(new double[] {3.2, 1.0, 5}, new double[] {4.3, 1.2, 6.7}, true);
+        assertTrue(Arrays.equals(new double[] { 20.0, 82.0, 255.0 }, img.getPoint(x, y)));
+        img.release();
+    }
+
+    @Test
+    public void TestLinearThrowsIfArraySizeAreNotEqual() throws IOException, VipsException {
+        ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
+        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
+
+        try {
+            img.linear(new double[]{3.2, 1.0, 5}, new double[]{1.2, 6.7});
+            img.release();
+            fail();
+        }
+        catch (VipsException e) {
+            img.release();
+        }
+    }
 }


### PR DESCRIPTION
As the binding is to vips' C interface, both arrays must have the same
length.