### PR TITLE
Make all fields in Max1Result public

### DIFF
--- a/src/main/java/com/criteo/vips/Max1Result.java
+++ b/src/main/java/com/criteo/vips/Max1Result.java
@@ -17,9 +17,9 @@
 package com.criteo.vips;
 
 public class Max1Result {
-    int x;
-    int y;
-    double out;
+    public int x;
+    public int y;
+    public double out;
     static {
         initMax1ResultFieldIDs();
     }


### PR DESCRIPTION
The fields in Max1Result need to be public so that code using the package can access them.