### PR TITLE
Implement autorotate

### DIFF
--- a/src/main/c/VipsImage.c
+++ b/src/main/c/VipsImage.c
@@ -165,6 +165,18 @@ Java_com_criteo_vips_VipsImageImpl_resizeNative(JNIEnv *env, jobject obj, jint w
 }
 
 JNIEXPORT void JNICALL
+Java_com_criteo_vips_VipsImageImpl_autoRotateNative(JNIEnv *env, jobject obj)
+{
+    VipsImage *im = (VipsImage *) (*env)->GetLongField(env, obj, handle_fid);
+    VipsImage *out = NULL;
+
+    vips_autorot(im, &out, NULL);
+
+    (*env)->SetLongField(env, obj, handle_fid, (jlong) out);
+    g_object_unref(im);
+}
+
+JNIEXPORT void JNICALL
 Java_com_criteo_vips_VipsImageImpl_padNative(JNIEnv *env, jobject obj, jint width, jint height, jdoubleArray background, jint gravity)
 {
     VipsImage *im = (VipsImage *) (*env)->GetLongField(env, obj, handle_fid);

--- a/src/main/c/VipsImage.h
+++ b/src/main/c/VipsImage.h
@@ -113,6 +113,14 @@ JNIEXPORT void JNICALL Java_com_criteo_vips_VipsImageImpl_resizeNative
 
 /*
  * Class:     com_criteo_vips_VipsImageImpl
+ * Method:    autoRotateNative
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_criteo_vips_VipsImageImpl_autoRotateNative
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_criteo_vips_VipsImageImpl
  * Method:    max1Native
  * Signature: (Lcom/criteo/vips/Max1Result;)V
  */

--- a/src/main/java/com/criteo/vips/Vips.java
+++ b/src/main/java/com/criteo/vips/Vips.java
@@ -71,7 +71,7 @@ public class Vips {
             for (String library : libraries) {
                 loadLibraryFromJar(library);
             }
-        } catch (NullPointerException _) {
+        } catch (NullPointerException e) {
             return false;
         }
         return true;

--- a/src/main/java/com/criteo/vips/VipsImage.java
+++ b/src/main/java/com/criteo/vips/VipsImage.java
@@ -123,6 +123,13 @@ public interface VipsImage {
     void resize(Dimension dimension, boolean scale) throws VipsException;
 
     /**
+     * Auto rotates an image based on EXIF rotation information
+     *
+     * @throws VipsException
+     */
+    void autoRotate() throws VipsException;
+
+    /**
      * Pad VipsImage with new target dimension and background pixel
      *
      * @param dimension Target dimension

--- a/src/main/java/com/criteo/vips/VipsImageImpl.java
+++ b/src/main/java/com/criteo/vips/VipsImageImpl.java
@@ -165,6 +165,11 @@ public class VipsImageImpl extends Vips implements VipsImage {
 
     private native void resizeNative(int width, int height, boolean scale) throws VipsException;
 
+    public void autoRotate() throws VipsException {
+        autoRotateNative();
+    }
+    private native void autoRotateNative() throws VipsException;
+
     public Max1Result max1() throws VipsException {
         Max1Result r = new Max1Result();
         max1Native(r);


### PR DESCRIPTION
This PR adds an `vipsImage.autorotate()` method. I believe that this requires `libexif` to be present so that might need building in. I didn't get time to figure out how to do that as part of the jar build though.

See issue #26 