### PR TITLE
Make VipsException an unchecked exception

### DIFF
--- a/src/main/java/com/criteo/vips/VipsException.java
+++ b/src/main/java/com/criteo/vips/VipsException.java
@@ -16,7 +16,7 @@
 
 package com.criteo.vips;
 
-public class VipsException extends Exception {
+public class VipsException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     public VipsException(String message) {


### PR DESCRIPTION
Making `VipsException` an unchecked exception simplifies its usage in Java 8 streams and futures.