### PR TITLE
Make VipsImage closeable

### DIFF
--- a/src/main/java/com/criteo/vips/Vips.java
+++ b/src/main/java/com/criteo/vips/Vips.java
@@ -71,7 +71,7 @@ public class Vips {
             for (String library : libraries) {
                 loadLibraryFromJar(library);
             }
-        } catch (NullPointerException _) {
+        } catch (NullPointerException e) {
             return false;
         }
         return true;

--- a/src/main/java/com/criteo/vips/VipsImage.java
+++ b/src/main/java/com/criteo/vips/VipsImage.java
@@ -17,87 +17,99 @@
 package com.criteo.vips;
 
 import java.awt.*;
+import java.io.Closeable;
+import java.io.IOException;
 
-public interface VipsImage {
-    /** Pass image through a linear transform, ie. (@out = @in * @a + @b)
+public interface VipsImage extends Closeable {
+    /**
+     * Pass image through a linear transform, ie. (@out = @in * @a + @b)
      *
-     * @param a: (array length=n): array of constants for multiplication
-     * @param b: (array length=b.length): array of constants for addition
+     * @param a:     (array length=n): array of constants for multiplication
+     * @param b:     (array length=b.length): array of constants for addition
      * @param uchar: output uchar pixels if true
      * @throws VipsException
-     *
      */
     void linear(double[] a, double[] b, boolean uchar) throws VipsException;
 
-    /** Pass image through a linear transform, ie. (@out = @in * @a + @b)
+    /**
+     * Pass image through a linear transform, ie. (@out = @in * @a + @b)
      *
      * @param a: (array length=n): array of constants for multiplication
      * @param b: (array length=b.length): array of constants for addition
      * @throws VipsException
-     *
      */
     void linear(double[] a, double[] b) throws VipsException;
 
-    /** Read a single pixel from an image.
+    /**
+     * Read a single pixel from an image.
      *
      * @return The pixel values
      * @throws VipsException
      */
     double[] getPoint(int x, int y) throws VipsException;
 
-    /** Find the single largest value
+    /**
+     * Find the single largest value
      *
      * @return maximum value and x & y positions
      * @throws VipsException
      */
     Max1Result max1() throws VipsException;
 
-    /** Get the format of each band element.
+    /**
+     * Get the format of each band element.
      *
      * @return the image's format
      */
     VipsBandFormat imageGetFormat();
 
-    /** Convert to VIPS_FORMAT_CHAR without shifting
+    /**
+     * Convert to VIPS_FORMAT_CHAR without shifting
      *
      * @throws VipsException
      */
     void castUchar() throws VipsException;
 
-     /** Convert to VIPS_FORMAT_CHAR
-      *
-      * @param shift values are shifted
-      * @throws VipsException
-      */
+    /**
+     * Convert to VIPS_FORMAT_CHAR
+     *
+     * @param shift values are shifted
+     * @throws VipsException
+     */
     void castUchar(boolean shift) throws VipsException;
 
-    /** Convert to format without shifting
+    /**
+     * Convert to format without shifting
      *
      * @param format the image's new format
      * @throws VipsException
      */
     void cast(VipsBandFormat format) throws VipsException;
 
-    /** Convert to format
+    /**
+     * Convert to format
      *
      * @param format the image's new format
-     * @param shift integer values are shifted
+     * @param shift  integer values are shifted
      * @throws VipsException
      */
     void cast(VipsBandFormat format, boolean shift) throws VipsException;
 
-    /** Make a one, two or three dimensional histogram of a 1, 2 or 3 band image
+    /**
+     * Make a one, two or three dimensional histogram of a 1, 2 or 3 band image
      *
      * @param bins number of bins
      * @throws VipsException
      */
     void histFindNdim(int bins) throws VipsException;
 
-    /** Get the VipsInterpretation from the image header.
+    /**
+     * Get the VipsInterpretation from the image header.
      *
      * @return the VipsInterpretation set in the image header.
      */
     VipsInterpretation imageGetInterpretation();
+
     /**
      * Convert this VipsImage's colourspace to the given space
      *
@@ -105,14 +117,16 @@ public interface VipsImage {
      * @throws VipsException
      */
     void colourspace(VipsInterpretation space) throws VipsException;
+
     /**
      * Convert this VipsImage's colourspace to the given space
      *
-     * @param space the new colourspace.
+     * @param space        the new colourspace.
      * @param source_space the input colourspace.
      * @throws VipsException
      */
     void colourspace(VipsInterpretation space, VipsInterpretation source_space) throws VipsException;
+
     /**
      * Resize this VipsImage with new target dimension
      *
@@ -125,9 +139,9 @@ public interface VipsImage {
     /**
      * Pad VipsImage with new target dimension and background pixel
      *
-     * @param dimension Target dimension
+     * @param dimension  Target dimension
      * @param background Background pixel color to fill with
-     * @param gravity Gravity direction
+     * @param gravity    Gravity direction
      * @throws VipsException
      */
     void pad(Dimension dimension, PixelPacket background, Gravity gravity) throws VipsException;
@@ -145,11 +159,10 @@ public interface VipsImage {
     /**
      * Find VipsImage bounding box
      *
-     * @param threshold background threshold
+     * @param threshold  background threshold
      * @param background Background pixel color
-     *
      * @return Bounding box Rectangle (left edge, top edge, width, height)
-     *         If the image is entirely background, width == 0 and height == 0
+     * If the image is entirely background, width == 0 and height == 0
      * @throws VipsException
      */
     Rectangle findTrim(double threshold, PixelPacket background) throws VipsException;
@@ -174,7 +187,7 @@ public interface VipsImage {
      * Write VipsImage to byte array with default quality
      *
      * @param imageFormat Target extension
-     *                        Could not be GIF because libvips can't save in this format
+     *                    Could not be GIF because libvips can't save in this format
      * @return Byte array of encoded VipsImageImpl
      * @throws VipsException
      */
@@ -184,7 +197,7 @@ public interface VipsImage {
      * Write VipsImage to byte array
      *
      * @param imageFormat Target extension
-     *                        Could not be GIF because libvips can't save in this format
+     *                    Could not be GIF because libvips can't save in this format
      * @param quality     Output quality
      * @return Byte array of encoded VipsImageImpl
      * @throws VipsException
@@ -194,9 +207,9 @@ public interface VipsImage {
     /**
      * Write VipsImage to byte array in PNG output format
      *
-     * @param compression     Compression level
-     * @param palette         If true color quantification is enabled
-     * @param colors          Number of palette colors
+     * @param compression Compression level
+     * @param palette     If true color quantification is enabled
+     * @param colors      Number of palette colors
      * @return Byte array of encoded VipsImageImpl
      * @throws VipsException
      */
@@ -250,4 +263,12 @@ public interface VipsImage {
      * Release VipsImage reference
      */
     void release();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    default void close() throws IOException {
+        release();
+    }
 }

--- a/src/test/java/com/criteo/vips/VipsImageImplTest.java
+++ b/src/test/java/com/criteo/vips/VipsImageImplTest.java
@@ -16,7 +16,11 @@
 
 package com.criteo.vips;
 
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.FromDataPoints;
 import org.junit.experimental.theories.Theories;
@@ -25,17 +29,20 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import java.awt.*;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Arrays;
+import java.util.stream.IntStream;
 
 import static com.criteo.vips.VipsImageImpl.JPGQuality;
-import static junit.framework.Assert.assertEquals;
-import static org.junit.Assert.*;
-import java.util.stream.IntStream;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(Theories.class)
 public class VipsImageImplTest {
@@ -45,11 +52,12 @@ public class VipsImageImplTest {
     private static PixelPacket TransparentPixel = new PixelPacket(255.0, 255.0, 255.0, 0.0);
 
     private static Map<String, byte[]> SignatureByExtension = new HashMap<>();
+
     static {
-        SignatureByExtension.put(".jpg", new byte[] { (byte) 0xFF, (byte) 0xD8, (byte) 0xFF });
-        SignatureByExtension.put(".png", new byte[] { (byte) 137, 80, 78, 71, 13, 10, 26, 10 });
-        SignatureByExtension.put(".webp", new byte[] { 'R', 'I', 'F', 'F' });
-        SignatureByExtension.put(".gif", new byte[] { 'G', 'I', 'F' });
+        SignatureByExtension.put(".jpg", new byte[]{(byte) 0xFF, (byte) 0xD8, (byte) 0xFF});
+        SignatureByExtension.put(".png", new byte[]{(byte) 137, 80, 78, 71, 13, 10, 26, 10});
+        SignatureByExtension.put(".webp", new byte[]{'R', 'I', 'F', 'F'});
+        SignatureByExtension.put(".gif", new byte[]{'G', 'I', 'F'});
     }
 
     @DataPoints("filenames")
@@ -66,10 +74,12 @@ public class VipsImageImplTest {
         final int red;
         final int green;
         final int blue;
+
         @Override
         public String toString() {
-            return String.format(filename + " RGB " + red + " " + green + " " + blue);
+            return filename + " RGB " + red + " " + green + " " + blue;
         }
+
         DominantColour(String f, int red, int green, int blue) {
             filename = f;
             this.red = red;
@@ -100,118 +110,104 @@ public class VipsImageImplTest {
     public void TestShouldOpenCorrectly(@FromDataPoints("filenames") String filename) throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer(filename);
         byte[] bufferArray = VipsTestUtils.getByteArray(filename);
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-        img.release();
-        img = new VipsImageImpl(bufferArray, bufferArray.length);
-        img.release();
+        try (VipsImageImpl imgFromBuffer = new VipsImageImpl(buffer, buffer.capacity());
+             VipsImageImpl imgFromByteArray = new VipsImageImpl(bufferArray, bufferArray.length)) {
+            assertNotNull(imgFromBuffer);
+            assertNotNull(imgFromByteArray);
+        }
     }
 
     @Theory
     public void TestShouldOpenCorrectlyFromVipsImage(@FromDataPoints("filenames") String filename) throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer(filename);
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-        VipsImageImpl copy = new VipsImageImpl(img, WhitePixel);
-
-        assertEquals(WhitePixel, copy.getPointPixelPacket(new Point(0, 0)));
-        assertEquals(img.getWidth(), copy.getWidth());
-        assertEquals(img.getHeight(), copy.getHeight());
-        img.release();
-        copy.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
+             VipsImageImpl copy = new VipsImageImpl(img, WhitePixel)) {
+            assertEquals(WhitePixel, copy.getPointPixelPacket(new Point(0, 0)));
+            assertEquals(img.getWidth(), copy.getWidth());
+            assertEquals(img.getHeight(), copy.getHeight());
+        }
     }
 
     @Theory
     public void TestWriteFromDirectByteBufferShouldNotThrows(@FromDataPoints("filenames") String filename,
                                                              ImageFormat output,
-                                                             boolean strip)
-            throws IOException, VipsException {
+                                                             boolean strip) throws IOException, VipsException {
         Assume.assumeTrue(output != ImageFormat.GIF);
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer(filename);
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        try {
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
             byte[] out = img.writeToArray(output, JPGQuality, strip);
-        } catch (VipsException e) {
-            fail();
+            assertNotNull(out);
         }
-        img.release();
     }
 
     @Theory
     public void TestWriteFromByteArrayShouldNotThrows(@FromDataPoints("filenames") String filename,
                                                       ImageFormat output,
-                                                      boolean strip)
-            throws IOException, VipsException {
+                                                      boolean strip) throws IOException, VipsException {
         Assume.assumeTrue(output != ImageFormat.GIF);
         byte[] buffer = VipsTestUtils.getByteArray(filename);
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.length);
-
-        try {
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.length)) {
             byte[] out = img.writeToArray(output, JPGQuality, strip);
-        } catch (VipsException e) {
-            junit.framework.Assert.fail();
+            assertNotNull(out);
         }
-        img.release();
     }
 
     @Theory
     public void TestHistFindNdim1(@FromDataPoints("filenames") String filename) throws IOException, VipsException {
         byte[] buffer = VipsTestUtils.getByteArray(filename);
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.length);
-
-        img.histFindNdim(1);
-        assertEquals(1, img.getWidth());
-        assertEquals(1, img.getHeight());
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.length)) {
+            img.histFindNdim(1);
+            assertEquals(1, img.getWidth());
+            assertEquals(1, img.getHeight());
+        }
     }
 
     @Theory
     public void TestHistFindNdim2(@FromDataPoints("filenames") String filename) throws IOException, VipsException {
         byte[] buffer = VipsTestUtils.getByteArray(filename);
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.length);
-
-        img.histFindNdim(2);
-        assertEquals(2, img.getWidth());
-        assertEquals(2, img.getHeight());
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.length)) {
+            img.histFindNdim(2);
+            assertEquals(2, img.getWidth());
+            assertEquals(2, img.getHeight());
+        }
     }
 
     @Theory
     public void TestHistFindNdim10(@FromDataPoints("filenames") String filename) throws IOException, VipsException {
         byte[] buffer = VipsTestUtils.getByteArray(filename);
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.length);
-
-        img.histFindNdim(10);
-        assertEquals(10, img.getWidth());
-        assertEquals(10, img.getHeight());
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.length)) {
+            img.histFindNdim(10);
+            assertEquals(10, img.getWidth());
+            assertEquals(10, img.getHeight());
+        }
     }
 
     @Theory
     public void TestCastUchar(@FromDataPoints("filenames") String filename) throws IOException, VipsException {
         byte[] buffer = VipsTestUtils.getByteArray(filename);
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.length);
-
-        assertNotEquals(img.imageGetFormat(), VipsBandFormat.NOTSET);
-        img.cast(VipsBandFormat.DOUBLE);
-        assertEquals(img.imageGetFormat(), VipsBandFormat.DOUBLE);
-        img.castUchar(true);
-        assertEquals(img.imageGetFormat(), VipsBandFormat.UCHAR); // also checks that VipsBandFormat.UCHAR is correct
-        img.castUchar();
-        assertEquals(img.imageGetFormat(), VipsBandFormat.UCHAR);
-   }
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.length)) {
+            assertNotEquals(img.imageGetFormat(), VipsBandFormat.NOTSET);
+            img.cast(VipsBandFormat.DOUBLE);
+            assertEquals(img.imageGetFormat(), VipsBandFormat.DOUBLE);
+            img.castUchar(true);
+            assertEquals(img.imageGetFormat(), VipsBandFormat.UCHAR); // also checks that VipsBandFormat.UCHAR is correct
+            img.castUchar();
+            assertEquals(img.imageGetFormat(), VipsBandFormat.UCHAR);
+        }
+    }
 
     @Theory
     public void TestCast(@FromDataPoints("filenames") String filename) throws IOException, VipsException {
         byte[] buffer = VipsTestUtils.getByteArray(filename);
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.length);
-
-        assertNotEquals(img.imageGetFormat(), VipsBandFormat.NOTSET);
-        img.cast(VipsBandFormat.UCHAR, true);
-        assertEquals(img.imageGetFormat(), VipsBandFormat.UCHAR);
-        img.cast(VipsBandFormat.SHORT);
-        assertEquals(img.imageGetFormat(), VipsBandFormat.SHORT);
-        img.cast(VipsBandFormat.FLOAT);
-        assertEquals(img.imageGetFormat(), VipsBandFormat.FLOAT);
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.length)) {
+            assertNotEquals(img.imageGetFormat(), VipsBandFormat.NOTSET);
+            img.cast(VipsBandFormat.UCHAR, true);
+            assertEquals(img.imageGetFormat(), VipsBandFormat.UCHAR);
+            img.cast(VipsBandFormat.SHORT);
+            assertEquals(img.imageGetFormat(), VipsBandFormat.SHORT);
+            img.cast(VipsBandFormat.FLOAT);
+            assertEquals(img.imageGetFormat(), VipsBandFormat.FLOAT);
+        }
     }
 
     @Test
@@ -225,159 +221,152 @@ public class VipsImageImplTest {
     @Test
     public void TestImageGetInterpretationB_W() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("monochrome.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-        VipsInterpretation colourSpace = VipsInterpretation.B_W;
-
-        assertEquals(colourSpace, img.imageGetInterpretation());
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            VipsInterpretation colourSpace = VipsInterpretation.B_W;
+            assertEquals(colourSpace, img.imageGetInterpretation());
+        }
     }
 
     @Test
     public void TestImageGetInterpretationCMYK() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips_cmyk.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-        VipsInterpretation colourSpace = VipsInterpretation.CMYK;
-
-        assertEquals(colourSpace, img.imageGetInterpretation());
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            VipsInterpretation colourSpace = VipsInterpretation.CMYK;
+            assertEquals(colourSpace, img.imageGetInterpretation());
+        }
     }
 
     @Test
     public void TestChangeColourSpace() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-        VipsInterpretation beforeColourSpace = VipsInterpretation.sRGB;
-        VipsInterpretation afterColourSpace = VipsInterpretation.CMYK;
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            VipsInterpretation beforeColourSpace = VipsInterpretation.sRGB;
+            VipsInterpretation afterColourSpace = VipsInterpretation.CMYK;
 
-        assertEquals(beforeColourSpace, img.imageGetInterpretation());
-        img.colourspace(afterColourSpace);
-        assertEquals(afterColourSpace, img.imageGetInterpretation());
+            assertEquals(beforeColourSpace, img.imageGetInterpretation());
+            img.colourspace(afterColourSpace);
+            assertEquals(afterColourSpace, img.imageGetInterpretation());
+        }
     }
 
     @Test
     public void TestChangeColourSpaceWithSourceSpace() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-        VipsInterpretation beforeColourSpace = VipsInterpretation.sRGB;
-        VipsInterpretation afterColourSpace = VipsInterpretation.CMYK;
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            VipsInterpretation beforeColourSpace = VipsInterpretation.sRGB;
+            VipsInterpretation afterColourSpace = VipsInterpretation.CMYK;
 
-        assertEquals(beforeColourSpace, img.imageGetInterpretation());
-        img.colourspace(afterColourSpace, beforeColourSpace);
-        assertEquals(afterColourSpace, img.imageGetInterpretation());
+            assertEquals(beforeColourSpace, img.imageGetInterpretation());
+            img.colourspace(afterColourSpace, beforeColourSpace);
+            assertEquals(afterColourSpace, img.imageGetInterpretation());
+        }
     }
 
     @Test
     public void TestReturnCorrectDimensions() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
         int expectedWidth = 1920;
         int expectedHeight = 1080;
-
-        assertEquals(expectedWidth, img.getWidth());
-        assertEquals(expectedHeight, img.getHeight());
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            assertEquals(expectedWidth, img.getWidth());
+            assertEquals(expectedHeight, img.getHeight());
+        }
     }
 
     @Test
     public void TestShouldReturnCorrectFirstPixelValue() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        PixelPacket pixel = img.getPointPixelPacket(new Point(0, 0));
-        PixelPacket expected = new PixelPacket(0.0, 81.0, 216.0, 255.0);
-        assertTrue(expected.equals(pixel));
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            PixelPacket pixel = img.getPointPixelPacket(new Point(0, 0));
+            PixelPacket expected = new PixelPacket(0.0, 81.0, 216.0, 255.0);
+            assertEquals(expected, pixel);
+        }
     }
 
     @Test
     public void TestShouldHandleTransparentPixel() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("transparent.png");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
 
-        PixelPacket pixel = img.getPointPixelPacket(new Point(0, 0));
-        PixelPacket expected = new PixelPacket(0.0, 0.0, 0.0, 0.0);
-        assertTrue(expected.equals(pixel));
-        img.release();
+            PixelPacket pixel = img.getPointPixelPacket(new Point(0, 0));
+            PixelPacket expected = new PixelPacket(0.0, 0.0, 0.0, 0.0);
+            assertEquals(expected, pixel);
+        }
     }
 
     @Test
     public void TestShouldResizeAndKeepAspectRatio() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        double aspectRatio = (double) img.getWidth() / (double) img.getHeight();
-        img.resize(new Dimension(800,800), false);
-        assertEquals(800, img.getWidth());
-        assertEquals(450, img.getHeight());
-        assertEquals(aspectRatio, (double) img.getWidth() / (double) img.getHeight(), Delta);
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            double aspectRatio = (double) img.getWidth() / (double) img.getHeight();
+            img.resize(new Dimension(800, 800), false);
+            assertEquals(800, img.getWidth());
+            assertEquals(450, img.getHeight());
+            assertEquals(aspectRatio, (double) img.getWidth() / (double) img.getHeight(), Delta);
+        }
     }
 
     @Test
     public void TestShouldResizeWithExactDimension() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        img.resize(new Dimension(800,800), true);
-        assertEquals(800, img.getWidth());
-        assertEquals(800, img.getHeight());
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            img.resize(new Dimension(800, 800), true);
+            assertEquals(800, img.getWidth());
+            assertEquals(800, img.getHeight());
+        }
     }
 
     @Test
     public void TestShouldFlattenTransparentBackground() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("transparent.png");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-        PixelPacket blue = new PixelPacket(0, 0, 255);
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            PixelPacket blue = new PixelPacket(0, 0, 255);
 
-        img.flatten(blue);
-        PixelPacket topLeft = img.getPointPixelPacket(new Point(0, 0));
-        assertEquals(topLeft.r, blue.r);
-        assertEquals(topLeft.g, blue.g);
-        assertEquals(topLeft.b, blue.b);
-        img.release();
+            img.flatten(blue);
+            PixelPacket topLeft = img.getPointPixelPacket(new Point(0, 0));
+            assertEquals(topLeft.r, blue.r, Delta);
+            assertEquals(topLeft.g, blue.g, Delta);
+            assertEquals(topLeft.b, blue.b, Delta);
+        }
     }
 
     @Test
     public void TestShouldCropCorrectly() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        img.crop(new Rectangle(0, 0, 50, 50));
-        assertEquals(50, img.getWidth());
-        assertEquals(50, img.getHeight());
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            img.crop(new Rectangle(0, 0, 50, 50));
+            assertEquals(50, img.getWidth());
+            assertEquals(50, img.getHeight());
+        }
     }
 
     @Test
     public void TestShouldNotCropIfOutOfBoundCropBox() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-        int w = img.getWidth();
-        int h = img.getHeight();
-        Rectangle box = new Rectangle(0, 0, w + 1, h + 1);
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            int w = img.getWidth();
+            int h = img.getHeight();
+            Rectangle box = new Rectangle(0, 0, w + 1, h + 1);
 
-        try {
             img.crop(box);
             fail("Should throw VipsException");
         } catch (VipsException e) {
-        } finally {
-            img.release();
+            // Expected
         }
     }
 
     @Test
     public void TestShouldNotCropIfZeroWidthAndHeightBox() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("white.png");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-        int w = img.getWidth();
-        int h = img.getHeight();
-        Rectangle box = new Rectangle(w, h, 0, 0);
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            int w = img.getWidth();
+            int h = img.getHeight();
+            Rectangle box = new Rectangle(w, h, 0, 0);
 
-        try {
             img.crop(box);
             fail("Should throw VipsException");
         } catch (VipsException e) {
-        } finally {
-            img.release();
+            // Expected
         }
     }
 
@@ -385,34 +374,33 @@ public class VipsImageImplTest {
     public void TestShouldPadCorrectly() throws IOException, VipsException {
         PixelPacket pixel = new PixelPacket(255.0, 255.0, 255.0, 255.0);
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        int w = img.getWidth();
-        int h = img.getHeight();
-        // Surround image with a 10-pixel white band
-        img.pad(new Dimension(w + 20, h + 20), pixel, Gravity.CENTRE);
-        assertEquals(w + 20, img.getWidth());
-        assertEquals(h + 20, img.getHeight());
-        assertTrue(pixel.equals(img.getPointPixelPacket(new Point(0, 0))));
-        assertTrue(pixel.equals(img.getPointPixelPacket(new Point(img.getWidth() - 1, 0))));
-        assertTrue(pixel.equals(img.getPointPixelPacket(new Point(0, img.getHeight() - 1))));
-        assertTrue(pixel.equals(img.getPointPixelPacket(new Point(img.getWidth() - 1, img.getHeight() - 1))));
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            int w = img.getWidth();
+            int h = img.getHeight();
+            // Surround image with a 10-pixel white band
+            img.pad(new Dimension(w + 20, h + 20), pixel, Gravity.CENTRE);
+            assertEquals(w + 20, img.getWidth());
+            assertEquals(h + 20, img.getHeight());
+            assertEquals(pixel, img.getPointPixelPacket(new Point(0, 0)));
+            assertEquals(pixel, img.getPointPixelPacket(new Point(img.getWidth() - 1, 0)));
+            assertEquals(pixel, img.getPointPixelPacket(new Point(0, img.getHeight() - 1)));
+            assertEquals(pixel, img.getPointPixelPacket(new Point(img.getWidth() - 1, img.getHeight() - 1)));
+        }
     }
 
     @Test
     public void TestShouldPadPNGWithTransparentPixel() throws IOException, VipsException {
         PixelPacket pixel = new PixelPacket(0.0, 0.0, 255.0, 50.0);
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("transparent.png");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
 
-        // Surround image with a 10-pixel blue band
-        img.pad(new Dimension(img.getWidth() + 20, img.getHeight() + 20), pixel, Gravity.CENTRE);
-        assertTrue(pixel.equals(img.getPointPixelPacket(new Point(0, 0))));
-        assertTrue(pixel.equals(img.getPointPixelPacket(new Point(img.getWidth() - 1, 0))));
-        assertTrue(pixel.equals(img.getPointPixelPacket(new Point(0, img.getHeight() - 1))));
-        assertTrue(pixel.equals(img.getPointPixelPacket(new Point(img.getWidth() - 1, img.getHeight() - 1))));
-        img.release();
+            // Surround image with a 10-pixel blue band
+            img.pad(new Dimension(img.getWidth() + 20, img.getHeight() + 20), pixel, Gravity.CENTRE);
+            assertEquals(pixel, img.getPointPixelPacket(new Point(0, 0)));
+            assertEquals(pixel, img.getPointPixelPacket(new Point(img.getWidth() - 1, 0)));
+            assertEquals(pixel, img.getPointPixelPacket(new Point(0, img.getHeight() - 1)));
+            assertEquals(pixel, img.getPointPixelPacket(new Point(img.getWidth() - 1, img.getHeight() - 1)));
+        }
     }
 
     @Test
@@ -420,15 +408,14 @@ public class VipsImageImplTest {
         PixelPacket expected = new PixelPacket(0.0, 0.0, 255.0, 255.0);
         PixelPacket pixel = new PixelPacket(0.0, 0.0, 255.0, 50.0);
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        // Surround image with a 10-pixel blue band
-        img.pad(new Dimension(img.getWidth() + 20, img.getHeight() + 20), pixel, Gravity.CENTRE);
-        assertTrue(expected.equals(img.getPointPixelPacket(new Point(0, 0))));
-        assertTrue(expected.equals(img.getPointPixelPacket(new Point(img.getWidth() - 1, 0))));
-        assertTrue(expected.equals(img.getPointPixelPacket(new Point(0, img.getHeight() - 1))));
-        assertTrue(expected.equals(img.getPointPixelPacket(new Point(img.getWidth() - 1, img.getHeight() - 1))));
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            // Surround image with a 10-pixel blue band
+            img.pad(new Dimension(img.getWidth() + 20, img.getHeight() + 20), pixel, Gravity.CENTRE);
+            assertEquals(expected, img.getPointPixelPacket(new Point(0, 0)));
+            assertEquals(expected, img.getPointPixelPacket(new Point(img.getWidth() - 1, 0)));
+            assertEquals(expected, img.getPointPixelPacket(new Point(0, img.getHeight() - 1)));
+            assertEquals(expected, img.getPointPixelPacket(new Point(img.getWidth() - 1, img.getHeight() - 1)));
+        }
     }
 
     @Test
@@ -436,68 +423,61 @@ public class VipsImageImplTest {
         thrown.expect(VipsException.class);
         thrown.expectMessage("Unable to get image point");
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("transparent.png");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        int w = img.getWidth();
-        int h = img.getHeight();
-        // Try to access out of bound
-        try {
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            int w = img.getWidth();
+            int h = img.getHeight();
+            // Try to access out of bound
             img.getPointPixelPacket(new Point(w + 1, h + 1));
-        } finally {
-            img.release();
         }
     }
 
     @Test
     public void TestShouldGetPointMonochrome() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("monochrome.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        PixelPacket pixel = img.getPointPixelPacket(new Point(0, 0));
-        img.release();
-        assertEquals(255.0, pixel.getRed());
-        assertEquals(255.0, pixel.getGreen());
-        assertEquals(255.0, pixel.getBlue());
-        assertEquals(255.0, pixel.getAlpha());
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            PixelPacket pixel = img.getPointPixelPacket(new Point(0, 0));
+            assertEquals(255.0, pixel.getRed(), Delta);
+            assertEquals(255.0, pixel.getGreen(), Delta);
+            assertEquals(255.0, pixel.getBlue(), Delta);
+            assertEquals(255.0, pixel.getAlpha(), Delta);
+        }
     }
 
     @Test
     public void TestShouldGetPointMonochromeWithTransparency() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("monochrome_with_transparency.png");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
 
-        int w = img.getWidth();
-        int h = img.getHeight();
-        PixelPacket transparentPixel = img.getPointPixelPacket(new Point(0, 0));
-        // Image center is not transparent
-        PixelPacket pixel = img.getPointPixelPacket(new Point(w / 2, h / 2));
-        img.release();
-        assertEquals(255.0, transparentPixel.getRed());
-        assertEquals(255.0, transparentPixel.getGreen());
-        assertEquals(255.0, transparentPixel.getBlue());
-        assertEquals(0.0, transparentPixel.getAlpha());
-        assertEquals(82.0, pixel.getRed());
-        assertEquals(82.0, pixel.getGreen());
-        assertEquals(82.0, pixel.getBlue());
-        assertEquals(255.0, pixel.getAlpha());
+            int w = img.getWidth();
+            int h = img.getHeight();
+            PixelPacket transparentPixel = img.getPointPixelPacket(new Point(0, 0));
+            // Image center is not transparent
+            PixelPacket pixel = img.getPointPixelPacket(new Point(w / 2, h / 2));
+            assertEquals(255.0, transparentPixel.getRed(), Delta);
+            assertEquals(255.0, transparentPixel.getGreen(), Delta);
+            assertEquals(255.0, transparentPixel.getBlue(), Delta);
+            assertEquals(0.0, transparentPixel.getAlpha(), Delta);
+            assertEquals(82.0, pixel.getRed(), Delta);
+            assertEquals(82.0, pixel.getGreen(), Delta);
+            assertEquals(82.0, pixel.getBlue(), Delta);
+            assertEquals(255.0, pixel.getAlpha(), Delta);
+        }
     }
 
     @Test
     public void TestTransparentPNGShouldHasTransparency() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("transparent.png");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        assertTrue(img.hasAlpha());
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            assertTrue(img.hasAlpha());
+        }
     }
 
     @Test
     public void TestJpgShouldNotHasTransparency() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        assertFalse(img.hasAlpha());
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            assertFalse(img.hasAlpha());
+        }
     }
 
     @Theory
@@ -507,38 +487,35 @@ public class VipsImageImplTest {
         byte[] expected = SignatureByExtension.get(imageFormat.getFileExtension());
         byte[] signature = new byte[expected.length];
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer(filename);
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        byte[] out = img.writeToArray(imageFormat, JPGQuality, true);
-        img.release();
-        System.arraycopy(out, 0, signature, 0, signature.length);
-        assertArrayEquals(expected, signature);
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            byte[] out = img.writeToArray(imageFormat, JPGQuality, true);
+            System.arraycopy(out, 0, signature, 0, signature.length);
+            assertArrayEquals(expected, signature);
+        }
     }
 
     @Test
     public void TestShouldFindTrim() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("logo_with_padding_50x50.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        Rectangle boundingBox = img.findTrim(TrimThreshold, WhitePixel);
-        assertEquals(50, boundingBox.x);
-        assertEquals(50, boundingBox.y);
-        assertEquals(640, boundingBox.width);
-        assertEquals(640, boundingBox.height);
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            Rectangle boundingBox = img.findTrim(TrimThreshold, WhitePixel);
+            assertEquals(50, boundingBox.x);
+            assertEquals(50, boundingBox.y);
+            assertEquals(640, boundingBox.width);
+            assertEquals(640, boundingBox.height);
+        }
     }
 
     @Test
     public void TestShouldFindTrimWithTransparent() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("logo_with_transparent_padding_50x50.png");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        Rectangle boundingBox = img.findTrim(TrimThreshold, TransparentPixel);
-        assertEquals(50, boundingBox.x);
-        assertEquals(50, boundingBox.y);
-        assertEquals(640, boundingBox.width);
-        assertEquals(640, boundingBox.height);
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            Rectangle boundingBox = img.findTrim(TrimThreshold, TransparentPixel);
+            assertEquals(50, boundingBox.x);
+            assertEquals(50, boundingBox.y);
+            assertEquals(640, boundingBox.width);
+            assertEquals(640, boundingBox.height);
+        }
     }
 
     @Theory
@@ -547,22 +524,17 @@ public class VipsImageImplTest {
         Assume.assumeTrue(imageFormat != ImageFormat.GIF);
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer(filename);
         PixelPacket pixel = new PixelPacket(5.0, 255.0, 25.0);
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-        int width;
-        int height;
-
-        try {
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
             img.resize(new Dimension(400, 400), false);
-            width = img.getWidth();
-            height = img.getHeight();
+            int width = img.getWidth();
+            int height = img.getHeight();
             img.crop(new Rectangle(10, 10, width - 10, height - 10));
             width = img.getWidth();
             height = img.getHeight();
             img.pad(new Dimension(width + 10, height + 10), pixel, Gravity.CENTRE);
-            byte [] out = img.writeToArray(imageFormat, JPGQuality, true);
-            img.release();
-        } catch (VipsException e) {
-            fail();
+
+            byte[] out = img.writeToArray(imageFormat, JPGQuality, true);
+            assertNotNull(out);
         }
     }
 
@@ -571,93 +543,78 @@ public class VipsImageImplTest {
         // libvips can't save into gif format
         Assume.assumeTrue(imageFormat != ImageFormat.GIF);
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("olin.png");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        try {
-            byte [] out = img.writeToArray(imageFormat, JPGQuality, true);
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            byte[] out = img.writeToArray(imageFormat, JPGQuality, true);
             fail();
         } catch (VipsException e) {
             // Should throw a vips exception
-        } finally {
-            img.release();
         }
     }
 
     @Test
     public void TestShouldInsertSubImage() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("logo_with_transparent_padding_50x50.png");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-        VipsImageImpl background = new VipsImageImpl(img, WhitePixel);
-
-        background.compose(img);
-        assertTrue(WhitePixel.equals(background.getPointPixelPacket(new Point(0,0))));
-        img.release();
-        background.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
+             VipsImageImpl background = new VipsImageImpl(img, WhitePixel)) {
+            background.compose(img);
+            assertEquals(WhitePixel, background.getPointPixelPacket(new Point(0, 0)));
+        }
     }
 
     @Test
     public void TestGetPointShouldReturn256bitsValue() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("white_48_bits.png");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        PixelPacket p = img.getPointPixelPacket(new Point(0, 0));
-        assertEquals(255.0, p.getRed());
-        assertEquals(255.0, p.getGreen());
-        assertEquals(255.0, p.getBlue());
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            PixelPacket p = img.getPointPixelPacket(new Point(0, 0));
+            assertEquals(255.0, p.getRed(), Delta);
+            assertEquals(255.0, p.getGreen(), Delta);
+            assertEquals(255.0, p.getBlue(), Delta);
+        }
     }
 
     @Test
     public void TestShouldGuessColourspace() throws IOException, VipsException {
-        ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        Assert.assertEquals(VipsInterpretation.sRGB, img.getInterpretation());
-        img.release();
-        buffer = VipsTestUtils.getDirectByteBuffer("in_vips_cmyk.jpg");
-        img = new VipsImageImpl(buffer, buffer.capacity());
-        Assert.assertEquals(VipsInterpretation.CMYK, img.getInterpretation());
-        img.release();
+        ByteBuffer bufferSrgb = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
+        ByteBuffer bufferCmyk = VipsTestUtils.getDirectByteBuffer("in_vips_cmyk.jpg");
+        try (VipsImageImpl imgSrgb = new VipsImageImpl(bufferSrgb, bufferSrgb.capacity());
+             VipsImageImpl imgCmyk = new VipsImageImpl(bufferCmyk, bufferCmyk.capacity())) {
+            Assert.assertEquals(VipsInterpretation.sRGB, imgSrgb.getInterpretation());
+            Assert.assertEquals(VipsInterpretation.CMYK, imgCmyk.getInterpretation());
+        }
     }
 
     @Test
     public void TestShouldReturnExactFrameNumberFromAnimatedImage() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("cat.gif");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        assertEquals(5, img.getNbFrame());
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            assertEquals(5, img.getNbFrame());
+        }
     }
 
     @Test
     public void TestShouldReturnExactFrameNumberFromNonAnimatedImage() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        assertEquals(1, img.getNbFrame());
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            assertEquals(1, img.getNbFrame());
+        }
     }
 
     @Test
     public void TestImageWithNoMetadataReturOneFrameNumber() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("02.gif");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        assertEquals(1, img.getNbFrame());
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            assertEquals(1, img.getNbFrame());
+        }
     }
 
     @Test
     public void TestDoubleReleaseShouldNotThrow() throws IOException, VipsException {
         byte[] buffer = VipsTestUtils.getByteArray("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.length);
-        byte[] out = img.writeToArray(ImageFormat.JPG, JPGQuality, true);
-
-        try {
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.length)) {
+            byte[] out = img.writeToArray(ImageFormat.JPG, JPGQuality, true);
+            assertNotNull(out);
             img.release();
             img.release();
-        } catch (Exception e) {
-            junit.framework.Assert.fail();
         }
     }
 
@@ -667,165 +624,154 @@ public class VipsImageImplTest {
                                                          boolean strip)
             throws IOException, VipsException {
         byte[] buffer = VipsTestUtils.getByteArray(filename);
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.length);
         int compression = 9;
         int colors = 256;
-
-        try {
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.length)) {
             byte[] out = img.writePNGToArray(compression, palette, colors, strip);
-        } catch (VipsException e) {
-            junit.framework.Assert.fail();
+            assertNotNull(out);
         }
-        img.release();
     }
 
     @Test
     public void TestWritePNGFromByteArrayShouldShrinkOutputSize()
             throws IOException, VipsException {
         byte[] buffer = VipsTestUtils.getByteArray("logo_with_transparent_padding_50x50.png");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.length);
         int compression = 9;
         int colors = 256;
-
-        byte[] out = img.writePNGToArray(compression, true, colors, true);
-        Assert.assertTrue(buffer.length > out.length);
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.length)) {
+            byte[] out = img.writePNGToArray(compression, true, colors, true);
+            Assert.assertTrue(buffer.length > out.length);
+        }
     }
 
     @Theory
     public void TestDominantColour(@FromDataPoints("fileColours") DominantColour fileColour) throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer(fileColour.filename);
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
 
-        // implement https://gist.github.com/jcupitt/ee3afcbb931b41b4d7f4
-        int N_BINS = 10;
-        int BIN_SIZE = 256 / N_BINS;
-        img.colourspace(VipsInterpretation.sRGB);
-        img.histFindNdim(N_BINS);
-        Max1Result maxpos = img.max1();
-        double[] pixel = img.getPoint(maxpos.x, maxpos.y);
-        int band = IntStream.range(0, pixel.length)
-					.filter(i -> maxpos.out == pixel[i])
-					.findFirst()
-					.orElse(-1);
-        int red = maxpos.x * BIN_SIZE + BIN_SIZE / 2;
-        int green = maxpos.y * BIN_SIZE + BIN_SIZE / 2;
-        int blue = band * BIN_SIZE + BIN_SIZE / 2;
+            // implement https://gist.github.com/jcupitt/ee3afcbb931b41b4d7f4
+            int N_BINS = 10;
+            int BIN_SIZE = 256 / N_BINS;
+            img.colourspace(VipsInterpretation.sRGB);
+            img.histFindNdim(N_BINS);
+            Max1Result maxpos = img.max1();
+            double[] pixel = img.getPoint(maxpos.x, maxpos.y);
+            int band = IntStream.range(0, pixel.length)
+                    .filter(i -> maxpos.out == pixel[i])
+                    .findFirst()
+                    .orElse(-1);
+            int red = maxpos.x * BIN_SIZE + BIN_SIZE / 2;
+            int green = maxpos.y * BIN_SIZE + BIN_SIZE / 2;
+            int blue = band * BIN_SIZE + BIN_SIZE / 2;
 
-        assertEquals(fileColour.red, red);
-        assertEquals(fileColour.green, green);
-        assertEquals(fileColour.blue, blue);
-        img.release();
+            assertEquals(fileColour.red, red);
+            assertEquals(fileColour.green, green);
+            assertEquals(fileColour.blue, blue);
+        }
     }
 
     @Test
     public void TestMax1() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            Max1Result r = img.max1();
 
-        Max1Result r = img.max1();
-
-        assertEquals(255.0, r.out);
+            assertEquals(255.0, r.out, Delta);
+        }
     }
 
     @Test
     public void TestHistFindNdimMax1() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
         final int N_BINS = 10;
-        img.histFindNdim(N_BINS);
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            img.histFindNdim(N_BINS);
 
-        Max1Result r = img.max1();
+            Max1Result r = img.max1();
 
-        assertEquals(239667.0, r.out);
-        assertEquals(0, r.x);
-        assertEquals(4, r.y);
+            assertEquals(239667.0, r.out, Delta);
+            assertEquals(0, r.x);
+            assertEquals(4, r.y);
+        }
     }
 
     @Test
     public void TestGetPoint() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        double[] point = img.getPoint(33, 8);
-        assertEquals(3, point.length);
-        double expected[] = { 0, 84, 219 };
-        assertEquals(expected[0], point[0]);
-        assertEquals(expected[1], point[1]);
-        assertEquals(expected[2], point[2]);
-        assertTrue(Arrays.equals(expected, point));
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            double[] point = img.getPoint(33, 8);
+            assertEquals(3, point.length);
+            double[] expected = {0, 84, 219};
+            assertEquals(expected[0], point[0], Delta);
+            assertEquals(expected[1], point[1], Delta);
+            assertEquals(expected[2], point[2], Delta);
+            assertArrayEquals(expected, point, 0.0);
+        }
     }
 
     @Test
     public void TestHistFindNdimMax1GetPoint() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            img.histFindNdim(10);
+            Max1Result r = img.max1();
+            assertEquals(239667.0, r.out, Delta);
+            assertEquals(0, r.x);
+            assertEquals(4, r.y);
 
-        img.histFindNdim(10);
-        Max1Result r = img.max1();
-        assertEquals(239667.0, r.out);
-        assertEquals(0, r.x);
-        assertEquals(4, r.y);
-
-        double[] point = img.getPoint(r.x, r.y);
-        assertEquals(10, point.length);
-        double expected[] = { 0, 0, 15, 226, 1966, 10993, 101474, 239667, 61531, 1693 };
-        assertTrue(Arrays.equals(expected, point));
-        img.release();
+            double[] point = img.getPoint(r.x, r.y);
+            assertEquals(10, point.length);
+            double[] expected = {0, 0, 15, 226, 1966, 10993, 101474, 239667, 61531, 1693};
+            assertArrayEquals(expected, point, 0.0);
+        }
     }
 
     @Test
     public void TestGetPointLinear() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
         int x = 39;
         int y = 43;
-
-        assertTrue(Arrays.equals(new double[] { 5.0, 81.0, 218.0 }, img.getPoint(x, y)));
-        img.linear(new double[] {3.2, 1.0, 5}, new double[] {4.3, 1.2, 6.7});
-        assertTrue(Arrays.equals(new double[] { 20.299999237060547, 82.19999694824219, 1096.699951171875 }, img.getPoint(x, y)));
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            assertArrayEquals(new double[]{5.0, 81.0, 218.0}, img.getPoint(x, y), 0.0);
+            img.linear(new double[]{3.2, 1.0, 5}, new double[]{4.3, 1.2, 6.7});
+            assertArrayEquals(new double[]{20.299999237060547, 82.19999694824219, 1096.699951171875}, img.getPoint(x, y), 0.0);
+        }
     }
 
     @Test
     public void TestGetPointLinearUchar() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
         int x = 39;
         int y = 43;
-
-        assertTrue(Arrays.equals(new double[] { 5.0, 81.0, 218.0 }, img.getPoint(x, y)));
-        img.linear(new double[] {3.2, 1.0, 5}, new double[] {4.3, 1.2, 6.7}, true);
-        assertTrue(Arrays.equals(new double[] { 20.0, 82.0, 255.0 }, img.getPoint(x, y)));
-        img.release();
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
+            assertArrayEquals(new double[]{5.0, 81.0, 218.0}, img.getPoint(x, y), 0.0);
+            img.linear(new double[]{3.2, 1.0, 5}, new double[]{4.3, 1.2, 6.7}, true);
+            assertArrayEquals(new double[]{20.0, 82.0, 255.0}, img.getPoint(x, y), 0.0);
+        }
     }
 
     @Test
     public void TestLinearThrowsIfArraySizeAreNotEqual() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
-        VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity());
-
-        try {
+        try (VipsImageImpl img = new VipsImageImpl(buffer, buffer.capacity())) {
             img.linear(new double[]{3.2, 1.0, 5}, new double[]{1.2, 6.7});
-            img.release();
             fail();
-        }
-        catch (VipsException e) {
-            img.release();
+        } catch (VipsException e) {
+            // Expected
         }
     }
 
     @Test
-    public void TestBlack() throws VipsException {
+    public void TestBlack() throws IOException, VipsException {
         int width = 13;
         int height = 6;
-        VipsImageImpl img = VipsImageImpl.black(width, height);
-        double[] expected = new double[] { 0 };
-        for (int x = 0; x < width; x++)
-            for (int y = 0; y < height; y++)
-                assertArrayEquals(expected, img.getPoint(x, y), 0);
-        img.release();
+        double[] expected = new double[]{0};
+        try (VipsImageImpl img = VipsImageImpl.black(width, height)) {
+            for (int x = 0; x < width; x++) {
+                for (int y = 0; y < height; y++) {
+                    assertArrayEquals(expected, img.getPoint(x, y), 0);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
With `VipsImage` implementing `Closeable`, it's now possible to use it in a try-with-resources statement for resource management:

```java
try (VipsImageImpl img = new VipsImageImpl(...)) {
    // Do something with img
}
```

See also: https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html