### PR TITLE
Expose public resize method without awt Dimension

### DIFF
--- a/src/main/java/com/criteo/vips/Vips.java
+++ b/src/main/java/com/criteo/vips/Vips.java
@@ -88,6 +88,10 @@ public class Vips {
         String libName = System.mapLibraryName(name);
         File temp;
         try (InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(libName)) {
+            if (in == null) {
+                LOGGER.severe("Could not load lib '" + libName + "' via classloader");
+                return;
+            }
             byte[] buffer = new byte[1024];
             int read;
             temp = File.createTempFile(libName, "");

--- a/src/main/java/com/criteo/vips/Vips.java
+++ b/src/main/java/com/criteo/vips/Vips.java
@@ -20,10 +20,10 @@ import java.io.*;
 import java.util.logging.Logger;
 
 public class Vips {
-    private final static Logger logger = Logger.getLogger("com.criteo.thirdparty.Vips");
-    private static String SystemName = System.getProperty("os.name").toLowerCase();
+    private static final Logger LOGGER = Logger.getLogger("com.criteo.thirdparty.Vips");
+    private static final String SYSTEM_NAME = System.getProperty("os.name").toLowerCase();
 
-    private final static String[] linuxLibraries = {
+    private static final String[] LINUX_LIBRARIES = {
             "exif",
             "png16",
             "spng",
@@ -44,20 +44,20 @@ public class Vips {
      * "Can't find dependent libraries"
      * Thus, JVips.dll should use system libraries.
      * We only provide libimagequant because it's out of windows binaries release.
-     *
+     * <p>
      * TODO: add Windows 64 embedded libraries
      */
-    private final static String[] windowsLibraries = {
+    private final static String[] WINDOWS_LIBRARIES = {
             "libimagequant"
     };
 
     static {
         try {
             if (tryLoadLibrariesFromJar())
-                logger.info("JVips dependencies have been loaded from jar");
+                LOGGER.info("JVips dependencies have been loaded from jar");
             else
-                logger.info("Using JVips dependencies installed on system");
-            logger.info("Trying to load JVips");
+                LOGGER.info("Using JVips dependencies installed on system");
+            LOGGER.info("Trying to load JVips");
             loadLibraryFromJar("JVips");
             init();
         } catch (IOException e) {
@@ -68,7 +68,7 @@ public class Vips {
     }
 
     private static boolean tryLoadLibrariesFromJar() throws IOException {
-        String[] libraries = !isWindows() ? linuxLibraries : windowsLibraries;
+        String[] libraries = !isWindows() ? LINUX_LIBRARIES : WINDOWS_LIBRARIES;
         try {
             for (String library : libraries) {
                 loadLibraryFromJar(library);
@@ -80,7 +80,8 @@ public class Vips {
     }
 
     private static boolean isWindows() {
-        return SystemName.indexOf("win") >= 0;
+        // might be "Darwin" on macOS.
+        return SYSTEM_NAME.indexOf("win") >= 0;
     }
 
     private static void loadLibraryFromJar(String name) throws IOException {

--- a/src/main/java/com/criteo/vips/VipsImage.java
+++ b/src/main/java/com/criteo/vips/VipsImage.java
@@ -80,7 +80,7 @@ public class VipsImage extends Vips implements Image {
     private native void blackNative(int width, int height) throws VipsException;
 
     private void newFromImage(Image image, PixelPacket c) throws VipsException {
-        double[] color = { c.getRed(), c.getGreen(), c.getBlue(), c.getAlpha() };
+        double[] color = {c.getRed(), c.getGreen(), c.getBlue(), c.getAlpha()};
         newFromImageNative(image, color);
     }
 
@@ -130,8 +130,7 @@ public class VipsImage extends Vips implements Image {
 
     private native void colourspaceNative(int space, int source_space) throws VipsException;
 
-    public void histFindNdim(int bins) throws VipsException
-    {
+    public void histFindNdim(int bins) throws VipsException {
         histFindNdimNative(bins);
     }
 
@@ -139,6 +138,10 @@ public class VipsImage extends Vips implements Image {
 
     public void resize(Dimension dimension, boolean scale) throws VipsException {
         resizeNative(dimension.width, dimension.height, scale);
+    }
+
+    public void resize(int width, int height, boolean scale) throws VipsException {
+        resizeNative(width, height, scale);
     }
 
     private native void resizeNative(int width, int height, boolean scale) throws VipsException;
@@ -163,8 +166,7 @@ public class VipsImage extends Vips implements Image {
 
     private native void cropNative(int left, int top, int width, int height) throws VipsException;
 
-    public Rectangle findTrim(double threshold, PixelPacket background) throws VipsException
-    {
+    public Rectangle findTrim(double threshold, PixelPacket background) throws VipsException {
         int[] ret = findTrimNative(threshold, background.getComponents());
         return new Rectangle(ret[0], ret[1], ret[2], ret[3]);
     }
@@ -237,7 +239,7 @@ public class VipsImage extends Vips implements Image {
          * The name of the function in libvips is vips_image_get_interpretation
          * so the Java method should be called imageGetInterpretation.  Just
          * the correctly named function here.
-        */
+         */
         return imageGetInterpretation();
     }
 


### PR DESCRIPTION
In order to make resize work on GraalVM (which does not have java.awt.* classes) a resize method resize(int width, int height, boolean scale) is exposed.
Further static final variables have been renamed according to Java standards.