### PR TITLE
Fix docker layer caching in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,10 @@ jobs:
 
       - name: Cache Docker layers
         uses: satackey/action-docker-layer-caching@v0.0.8
+        with:
+          key: docker-layers-linux-{hash}
+          restore-keys: |
+            docker-layers-linux-
         # Ignore the failure of a step and avoid terminating the job.
         continue-on-error: true
 
@@ -37,11 +41,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Cache Docker layers
-        uses: satackey/action-docker-layer-caching@v0.0.8
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
 
       - name: Build Docker builder image
         run: docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -f .github/docker/windows/Dockerfile -t builder .


### PR DESCRIPTION
This is a workaround for the docker layer caching issue reported here: https://github.com/satackey/action-docker-layer-caching/issues/75

It removes the docker layer caching from the windows build, as the benefit was marginal there anyway. Doing this leaves more cache quota for the linux build which really needs it.

Also, the cache keys for the linux build job have been set explicitly. If you want to restore caching in the windows job, set a different key for that job.