### PR TITLE
Log the Vips error buffer when VipsException are thrown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,9 @@ script/enum-generator/vips-*
 script/enum-generator/enums
 script/enum-generator/test
 
+### Maven ###
+target/
+pom.xml.versionsBackup
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ target/
 script/enum-generator/vips-*
 script/enum-generator/enums
 script/enum-generator/test
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Install libvips with Homebrew:
 
 ## From source
 
-The build system relies on numerous dependencies including CMake 3 and Maven, as well as native code compilers. Instead of listing them here, please refer to [Dockerfile](Dockerfile) for an up-to-date list.
+The build system relies on numerous dependencies including CMake 3 and Maven, as well as native code compilers. Instead of listing them here, please refer to [Dockerfile](.github/docker/linux/Dockerfile) for an up-to-date list.
 
 The `build.sh` script will download and build a subset of JVips dependencies from source in order to maximize optimizations. However, it is recommended to install all dependencies on the system first, as documented in the sections below.
 
@@ -113,7 +113,7 @@ Windows builds are cross-compiled from Linux using MingW64. WSL and Docker are b
 
 To build with Docker:
 ```
-$ docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -f Dockerfile -t builder .
+$ docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -f .github/docker/windows/Dockerfile -t builder .
 $ docker run --rm -v $(pwd):/app -w /app builder bash -ex build.sh --with-w64 --without-linux --without-macos
 ```
 
@@ -196,7 +196,7 @@ Java_com_criteo_vips_VipsImageImpl_hasAlpha(JNIEnv *env, jobject obj)
 
 To debug the Docker image, you should build, run, and enter it as root:
 ```
-$ docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -f Dockerfile -t builder .
+$ docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -f .github/docker/linux/Dockerfile -t builder .
 $ docker run --rm -v $(pwd):/app -w /app -u root -it builder bash
 ```
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -220,11 +220,13 @@ if (WITH_LIBHEIF)
         ExternalProject_Add(libheif
           URL "https://github.com/strukturag/libheif/releases/download/v${HEIF_VERSION}/libheif-${HEIF_VERSION}.tar.gz"
           PREFIX "${CMAKE_CURRENT_BINARY_DIR}/libheif"
-          CONFIGURE_COMMAND ${CMAKE_CURRENT_BINARY_DIR}/libheif/src/libheif/configure
-          ${CONFIGURE_VARS}
-          --disable-go
-          --with-aom
-          DEPENDS libaom
+          CMAKE_ARGS
+          -DCMAKE_INSTALL_PREFIX=${EXT_INSTALL_DIR}
+          -DCMAKE_BUILD_TYPE=Release
+          -DHAVE_AOM=yes
+          -DHAVE_GO=no
+           DEPENDS libaom
+          BUILD_IN_SOURCE 1
           )
     else()
         add_custom_target(libheif "")

--- a/src/main/java/com/criteo/vips/VipsException.java
+++ b/src/main/java/com/criteo/vips/VipsException.java
@@ -19,7 +19,23 @@ package com.criteo.vips;
 public class VipsException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
+    private String vipsErrorBuffer;
+
     public VipsException(String message) {
         super(message);
+    }
+
+    public VipsException(String message, String vipsErrorBuffer) {
+        super(message);
+        this.vipsErrorBuffer = vipsErrorBuffer;
+    }
+
+    @Override
+    public String getMessage() {
+        String msg = super.getMessage();
+        if (vipsErrorBuffer != null) {
+            return msg + '\n' + " vips error buffer contains: " + vipsErrorBuffer.trim();
+        }
+        return msg;
     }
 }

--- a/src/test/c/CMakeLists.txt
+++ b/src/test/c/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(JVipsTest SHARED VipsEnumTest.c ${PROJECT_SOURCE_DIR}/src/main/c/Vip
 
 add_dependencies(JVipsTest JVips VipsEnumTest_header)
 
-target_link_libraries(JVipsTest ${VIPS_LIBRARIES})
+target_link_libraries(JVipsTest ${VIPS_LIBRARIES} "-lvips")
 target_include_directories(JVipsTest PUBLIC ${PROJECT_SOURCE_DIR}/src/main/c)
 
 if ("${BUILD_TARGET}" STREQUAL "w64")


### PR DESCRIPTION
Hello

I needed to test and debug some C code in the JVips project.

To better diagnose the errors that can be encountered with libvips, it is possible to retrieve the contents of the Vips error buffer with : https://github.com/libvips/libvips/blob/master/libvips/iofuncs/error.c#L178

This buffer contains possible explanations of why a libvips call might have failed, and it helped me a lot during my tests.

That's why I propose this PR to log the content of the Vips error buffer when a VipsException is thrown from the C code :)

Anthony