### PR TITLE
Limit test dependencies to the test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,11 +324,13 @@
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
             <version>1.21</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
             <version>1.21</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Now, these dependencies are declared in compile scope and will be included in any project which depends on the JVips.