### PR TITLE
Add vips_resize binding and deprecate resize method in favor of thumbnailImage

### DIFF
--- a/src/main/c/VipsImage.c
+++ b/src/main/c/VipsImage.c
@@ -168,7 +168,7 @@ Java_com_criteo_vips_VipsImage_colourspaceNative__II(JNIEnv *env, jobject obj, i
 }
 
 JNIEXPORT void JNICALL
-Java_com_criteo_vips_VipsImage_resizeNative(JNIEnv *env, jobject obj, jint width, jint height, jboolean scale)
+Java_com_criteo_vips_VipsImage_thumbnailImageNative(JNIEnv *env, jobject obj, jint width, jint height, jboolean scale)
 {
     VipsImage *im = (VipsImage *) (*env)->GetLongField(env, obj, handle_fid);
     VipsImage *out = NULL;
@@ -176,7 +176,7 @@ Java_com_criteo_vips_VipsImage_resizeNative(JNIEnv *env, jobject obj, jint width
 
     if (vips_thumbnail_image(im, &out, width, "height", height, "size", vipsSize, NULL))
     {
-        throwVipsException(env, "Unable to resize image");
+        throwVipsException(env, "Unable to make thumbnail image");
         return;
     }
     (*env)->SetLongField(env, obj, handle_fid, (jlong) out);

--- a/src/main/c/VipsImage.c
+++ b/src/main/c/VipsImage.c
@@ -184,6 +184,21 @@ Java_com_criteo_vips_VipsImage_thumbnailImageNative(JNIEnv *env, jobject obj, ji
 }
 
 JNIEXPORT void JNICALL
+Java_com_criteo_vips_VipsImage_resizeNative(JNIEnv *env, jobject obj, jdouble hscale, jdouble vscale, jint kernel)
+{
+    VipsImage *im = (VipsImage *) (*env)->GetLongField(env, obj, handle_fid);
+    VipsImage *out = NULL;
+
+    if (vips_resize(im, &out, hscale, "vscale", vscale, "kernel", kernel, NULL))
+    {
+        throwVipsException(env, "Unable to resize image");
+        return;
+    }
+    (*env)->SetLongField(env, obj, handle_fid, (jlong) out);
+    g_object_unref(im);
+}
+
+JNIEXPORT void JNICALL
 Java_com_criteo_vips_VipsImage_padNative(JNIEnv *env, jobject obj, jint width, jint height, jdoubleArray background, jint gravity)
 {
     VipsImage *im = (VipsImage *) (*env)->GetLongField(env, obj, handle_fid);

--- a/src/main/c/VipsImage.h
+++ b/src/main/c/VipsImage.h
@@ -121,6 +121,14 @@ JNIEXPORT void JNICALL Java_com_criteo_vips_VipsImage_thumbnailImageNative
 
 /*
  * Class:     com_criteo_vips_VipsImage
+ * Method:    resizeNative
+ * Signature: (DDI)V
+ */
+JNIEXPORT void JNICALL Java_com_criteo_vips_VipsImage_resizeNative
+  (JNIEnv *, jobject, jdouble, jdouble, jint);
+
+/*
+ * Class:     com_criteo_vips_VipsImage
  * Method:    max1Native
  * Signature: (Lcom/criteo/vips/Max1Result;)V
  */

--- a/src/main/c/VipsImage.h
+++ b/src/main/c/VipsImage.h
@@ -113,10 +113,10 @@ JNIEXPORT void JNICALL Java_com_criteo_vips_VipsImage_histFindNdimNative
 
 /*
  * Class:     com_criteo_vips_VipsImage
- * Method:    resizeNative
+ * Method:    thumbnailImageNative
  * Signature: (IIZ)V
  */
-JNIEXPORT void JNICALL Java_com_criteo_vips_VipsImage_resizeNative
+JNIEXPORT void JNICALL Java_com_criteo_vips_VipsImage_thumbnailImageNative
   (JNIEnv *, jobject, jint, jint, jboolean);
 
 /*

--- a/src/main/java/com/criteo/vips/Image.java
+++ b/src/main/java/com/criteo/vips/Image.java
@@ -161,6 +161,16 @@ public interface Image extends AutoCloseable {
     void resize(Dimension dimension, boolean scale) throws VipsException;
 
     /**
+     * Resize this VipsImage with target scaling factor and resampling kernel
+     *
+     * @param hscale Horizontal scale factor
+     * @param vscale Vertical scale factor
+     * @param kernel Resampling kernel
+     * @throws VipsException if error
+     */
+    void resize(double hscale, double vscale, VipsKernel kernel) throws VipsException;
+
+    /**
      * Pad VipsImage with new target dimension and background pixel
      *
      * @param dimension  Target dimension

--- a/src/main/java/com/criteo/vips/Image.java
+++ b/src/main/java/com/criteo/vips/Image.java
@@ -253,6 +253,16 @@ public interface Image extends AutoCloseable {
     byte[] writePNGToArray(int compression, boolean palette, int colors, boolean strip) throws VipsException;
 
     /**
+     * Write a VIPS Image to byte array in JPEG output format
+     *
+     * @param quality Quality factor
+     * @param strip Whether to remove all metadata from image
+     * @return Byte array of encoded VipsImageImpl
+     * @throws VipsException if error
+     */
+    byte[] writeJPEGToArray(int quality, boolean strip) throws VipsException;
+
+    /**
      * Write VipsImage to file
      *
      * @param name Output file name

--- a/src/main/java/com/criteo/vips/Image.java
+++ b/src/main/java/com/criteo/vips/Image.java
@@ -130,12 +130,34 @@ public interface Image extends AutoCloseable {
     void colourspace(VipsInterpretation space, VipsInterpretation source_space) throws VipsException;
 
     /**
-     * Resize this VipsImage with new target dimension
+     * Make a thumbnail of this VipsImage with new target dimension
      *
      * @param dimension Target dimension
      * @param scale     If scale is enabled, force to resize ignoring aspect ratio
      * @throws VipsException if error
      */
+    void thumbnailImage(Dimension dimension, boolean scale) throws VipsException;
+
+    /**
+     * Make a thumbnail of this VipsImage with new target dimension
+     *
+     * @param width  Target width
+     * @param height Target height
+     * @param scale  If scale is enabled, force to resize ignoring aspect ratio
+     * @throws VipsException if error
+     */
+    void thumbnailImage(int width, int height, boolean scale) throws VipsException;
+
+    /**
+     * Make a thumbnail of this VipsImage with new target dimension
+     *
+     * @param dimension Target dimension
+     * @param scale     If scale is enabled, force to resize ignoring aspect ratio
+     * @throws VipsException if error
+     *
+     * @deprecated Use {@link #thumbnailImage(Dimension, boolean)} instead.
+     */
+    @Deprecated
     void resize(Dimension dimension, boolean scale) throws VipsException;
 
     /**

--- a/src/main/java/com/criteo/vips/VipsImage.java
+++ b/src/main/java/com/criteo/vips/VipsImage.java
@@ -136,15 +136,31 @@ public class VipsImage extends Vips implements Image {
 
     private native void histFindNdimNative(int bins) throws VipsException;
 
+    public void thumbnailImage(Dimension dimension, boolean scale) throws VipsException {
+        thumbnailImageNative(dimension.width, dimension.height, scale);
+    }
+
+    public void thumbnailImage(int width, int height, boolean scale) throws VipsException {
+        thumbnailImageNative(width, height, scale);
+    }
+
+    /**
+     * @deprecated Use {@link #thumbnailImage(Dimension, boolean)} instead.
+     */
+    @Deprecated
     public void resize(Dimension dimension, boolean scale) throws VipsException {
-        resizeNative(dimension.width, dimension.height, scale);
+        thumbnailImageNative(dimension.width, dimension.height, scale);
     }
 
+    /**
+     * @deprecated Use {@link #thumbnailImage(int, int, boolean)} instead.
+     */
+    @Deprecated
     public void resize(int width, int height, boolean scale) throws VipsException {
-        resizeNative(width, height, scale);
+        thumbnailImageNative(width, height, scale);
     }
 
-    private native void resizeNative(int width, int height, boolean scale) throws VipsException;
+    private native void thumbnailImageNative(int width, int height, boolean scale) throws VipsException;
 
     public Max1Result max1() throws VipsException {
         Max1Result r = new Max1Result();

--- a/src/main/java/com/criteo/vips/VipsImage.java
+++ b/src/main/java/com/criteo/vips/VipsImage.java
@@ -162,6 +162,12 @@ public class VipsImage extends Vips implements Image {
 
     private native void thumbnailImageNative(int width, int height, boolean scale) throws VipsException;
 
+    public void resize(double hscale, double vscale, VipsKernel kernel) throws VipsException {
+        resizeNative(hscale, vscale, kernel.getValue());
+    }
+
+    private native void resizeNative(double hscale, double vscale, int kernel) throws VipsException;
+
     public Max1Result max1() throws VipsException {
         Max1Result r = new Max1Result();
         max1Native(r);

--- a/src/main/java/com/criteo/vips/VipsImage.java
+++ b/src/main/java/com/criteo/vips/VipsImage.java
@@ -220,13 +220,6 @@ public class VipsImage extends Vips implements Image {
 
     private native byte[] writePNGToArrayNative(int compression, boolean palette, int colors, boolean strip) throws VipsException;
 
-    /**
-     * Write a VIPS Image to a byte array as JPEG
-     * @param quality Quality factor
-     * @param strip Whether to remove all metadata from image
-     * @return JPEG image as byte array
-     * @throws VipsException
-     */
     public byte[] writeJPEGToArray(int quality, boolean strip) throws VipsException {
         return writeJPEGToArrayNative(quality, strip);
     }

--- a/src/test/java/com/criteo/vips/VipsImageTest.java
+++ b/src/test/java/com/criteo/vips/VipsImageTest.java
@@ -332,7 +332,17 @@ public class VipsImageTest {
     }
 
     @Test
-    public void TestShouldFlattenTransparentBackground() throws IOException, VipsException {
+    public void TestShouldResize() throws IOException, VipsException {
+        ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
+        try (VipsImage img = new VipsImage(buffer, buffer.capacity())) {
+            img.resize(2.0, 2.0, VipsKernel.Cubic);
+            assertEquals(3840, img.getWidth());
+            assertEquals(2160, img.getHeight());
+        }
+    }
+
+    @Test
+    public void TestShouldFlattenTransparanentBackground() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("transparent.png");
         try (VipsImage img = new VipsImage(buffer, buffer.capacity())) {
             PixelPacket blue = new PixelPacket(0, 0, 255);

--- a/src/test/java/com/criteo/vips/VipsImageTest.java
+++ b/src/test/java/com/criteo/vips/VipsImageTest.java
@@ -310,11 +310,11 @@ public class VipsImageTest {
     }
 
     @Test
-    public void TestShouldResizeAndKeepAspectRatio() throws IOException, VipsException {
+    public void TestShouldRenderThumbnailAndKeepAspectRatio() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
         try (VipsImage img = new VipsImage(buffer, buffer.capacity())) {
             double aspectRatio = (double) img.getWidth() / (double) img.getHeight();
-            img.resize(new Dimension(800, 800), false);
+            img.thumbnailImage(new Dimension(800, 800), false);
             assertEquals(800, img.getWidth());
             assertEquals(450, img.getHeight());
             assertEquals(aspectRatio, (double) img.getWidth() / (double) img.getHeight(), Delta);
@@ -322,10 +322,10 @@ public class VipsImageTest {
     }
 
     @Test
-    public void TestShouldResizeWithExactDimension() throws IOException, VipsException {
+    public void TestShouldRenderThumbnailWithExactDimension() throws IOException, VipsException {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer("in_vips.jpg");
         try (VipsImage img = new VipsImage(buffer, buffer.capacity())) {
-            img.resize(new Dimension(800, 800), true);
+            img.thumbnailImage(new Dimension(800, 800), true);
             assertEquals(800, img.getWidth());
             assertEquals(800, img.getHeight());
         }
@@ -542,7 +542,7 @@ public class VipsImageTest {
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer(filename);
         PixelPacket pixel = new PixelPacket(5.0, 255.0, 25.0);
         try (VipsImage img = new VipsImage(buffer, buffer.capacity())) {
-            img.resize(new Dimension(400, 400), false);
+            img.thumbnailImage(new Dimension(400, 400), false);
             int width = img.getWidth();
             int height = img.getHeight();
             img.crop(new Rectangle(10, 10, width - 10, height - 10));

--- a/src/test/java/com/criteo/vips/benchmark/SimpleBenchmark.java
+++ b/src/test/java/com/criteo/vips/benchmark/SimpleBenchmark.java
@@ -35,7 +35,7 @@ import java.nio.file.Files;
 import java.util.concurrent.TimeUnit;
 
 public class SimpleBenchmark {
-    private static Dimension resizeTarget = new Dimension(512, 512);
+    private static Dimension thumbnailTarget = new Dimension(512, 512);
     private static Rectangle cropTarget = new Rectangle(128, 128, 128, 128);
     private static Dimension padTarget = new Dimension(256, 256);
     private static PixelPacket pixelPacket = new PixelPacket(255.0, 255.0, 255.0);
@@ -80,19 +80,19 @@ public class SimpleBenchmark {
     }
 
     @Benchmark
-    public void ResizeCropPadJpeg(BenchmarkState state, Blackhole bh) {
-        ResizeCropPad(state.jpegContent, VipsImageFormat.JPG);
+    public void ThumbnailCropPadJpeg(BenchmarkState state, Blackhole bh) {
+        ThumbnailCropPad(state.jpegContent, VipsImageFormat.JPG);
     }
 
     @Benchmark
-    public void ResizeCropPadPng(BenchmarkState state, Blackhole bh) {
-        ResizeCropPad(state.pngContent, VipsImageFormat.PNG);
+    public void ThumbnailCropPadPng(BenchmarkState state, Blackhole bh) {
+        ThumbnailCropPad(state.pngContent, VipsImageFormat.PNG);
     }
 
-    private void ResizeCropPad(byte[] content, VipsImageFormat format) {
+    private void ThumbnailCropPad(byte[] content, VipsImageFormat format) {
         VipsImage img = new VipsImage(content, content.length);
 
-        img.resize(resizeTarget, false);
+        img.thumbnailImage(thumbnailTarget, false);
         img.crop(cropTarget);
         img.pad(padTarget, pixelPacket, VipsCompassDirection.Centre);
         byte[] out = img.writeToArray(format, 80, false);

--- a/src/test/java/com/criteo/vips/example/ExecutorServiceExample.java
+++ b/src/test/java/com/criteo/vips/example/ExecutorServiceExample.java
@@ -47,7 +47,7 @@ public class ExecutorServiceExample {
                     @Override
                     public Void call() throws Exception {
                         try (VipsImage image = new VipsImage(contents.clone(), contents.length);) {
-                            image.resize(new Dimension(256, 256), true);
+                            image.thumbnailImage(new Dimension(256, 256), true);
                             image.pad(new Dimension(512, 512),
                                     new PixelPacket(255, 255, 255),
                                     VipsCompassDirection.Centre);

--- a/src/test/java/com/criteo/vips/example/SimpleExample.java
+++ b/src/test/java/com/criteo/vips/example/SimpleExample.java
@@ -35,7 +35,7 @@ public class SimpleExample {
             int width = image.getWidth();
             int height = image.getHeight();
 
-            image.resize(new Dimension(width / 2, height / 2), true);
+            image.thumbnailImage(new Dimension(width / 2, height / 2), true);
             System.out.println(String.format("Image has been correctly resized: (%d,%d) -> (%d,%d)",
                     width, height, image.getWidth(), image.getHeight()));
             contents = image.writeToArray(VipsImageFormat.JPG, false);


### PR DESCRIPTION
Hello !

I needed to resize some images using JVips recently.
However, like described in this issue (#72), the `vips_thumbnail_image` binding produces bad quality images.

That's why I needed to use the `vips_resize` binding to resize VipsImage by specifying:

* A horizontal and a vertical scaling factor
* A kernel resampling (using bicubic interpolation)

Using a bicubic interpolation with `vips_resize` produce higher quality images compared to the `vips_thumbnail_image` binding.

However, to avoid method name conflicts between these bindings and to avoid breaking the JVips API, I had to:

* Deprecate `Image.resize(dimension, scale)` in favor of `Image.thumbnailImage(dimension, scale)`
* Add `Image.resize(hscale, vscale, kernel)` and bind it to `vips_resize`

What do you think about these changes?

Anthony