### PR TITLE
Fix heif Linux build and writeToArrayNative

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -250,6 +250,7 @@ if (WITH_LIBHEIF)
           PREFIX "${CMAKE_CURRENT_BINARY_DIR}/libheif"
           CMAKE_ARGS
           -DCMAKE_INSTALL_PREFIX=${EXT_INSTALL_DIR}
+          -DCMAKE_INSTALL_LIBDIR=lib
           -DCMAKE_BUILD_TYPE=Release
           -DHAVE_AOM=yes
           -DHAVE_GO=no

--- a/src/main/c/VipsImage.c
+++ b/src/main/c/VipsImage.c
@@ -409,9 +409,9 @@ Java_com_criteo_vips_VipsImage_writeToArrayNative(JNIEnv *env, jobject obj, jstr
 
     if (strcmp(ext, ".avif") == 0) {
         if (quality < 0)
-            status = vips_heifsave_buffer(im, &buffer, &result_length, "Q", quality, "compression", VIPS_FOREIGN_HEIF_COMPRESSION_AV1, NULL);
-        else
             status = vips_heifsave_buffer(im, &buffer, &result_length, "compression", VIPS_FOREIGN_HEIF_COMPRESSION_AV1, NULL);
+        else
+            status = vips_heifsave_buffer(im, &buffer, &result_length, "Q", quality, "compression", VIPS_FOREIGN_HEIF_COMPRESSION_AV1, NULL);
     } else {
         if (quality < 0)
             status = vips_image_write_to_buffer(im, ext, &buffer, &result_length, "strip", strip, NULL);

--- a/src/test/java/com/criteo/vips/VipsImageTest.java
+++ b/src/test/java/com/criteo/vips/VipsImageTest.java
@@ -66,6 +66,10 @@ public class VipsImageTest {
         SignaturesByExtension.put(".webp", new ArrayList() {{ add(new Byte[]{'R', 'I', 'F', 'F'}); }});
         SignaturesByExtension.put(".gif", new ArrayList() {{ add(new Byte[]{'G', 'I', 'F'}); }});
         SignaturesByExtension.put(".avif", new ArrayList() {{ add(new Byte[]{(byte)
+            0x00, 0x00, 0x00, 0x1c,
+            'f', 't', 'y', 'p', 'a', 'v', 'i', 'f' 
+        });
+        add(new Byte[]{(byte)
             0x00, 0x00, 0x00, 0x18,
             'f', 't', 'y', 'p', 'a', 'v', 'i', 'f' 
         }); }});
@@ -152,7 +156,6 @@ public class VipsImageTest {
                                                              VipsImageFormat output,
                                                              boolean strip) throws IOException, VipsException {
         Assume.assumeTrue(output != VipsImageFormat.GIF);
-        Assume.assumeTrue(output != VipsImageFormat.AVIF);
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer(filename);
         try (VipsImage img = new VipsImage(buffer, buffer.capacity())) {
             byte[] out = img.writeToArray(output, JPGQuality, strip);
@@ -165,7 +168,6 @@ public class VipsImageTest {
                                                       VipsImageFormat output,
                                                       boolean strip) throws IOException, VipsException {
         Assume.assumeTrue(output != VipsImageFormat.GIF);
-        Assume.assumeTrue(output != VipsImageFormat.AVIF);
         byte[] buffer = VipsTestUtils.getByteArray(filename);
         try (VipsImage img = new VipsImage(buffer, buffer.length)) {
             byte[] out = img.writeToArray(output, JPGQuality, strip);
@@ -530,7 +532,6 @@ public class VipsImageTest {
     public void TestShouldWriteToArrayHasCorrectHeaderSignature(String filename, VipsImageFormat vipsImageFormat) throws IOException, VipsException {
         // libvips can't save into gif format
         Assume.assumeTrue(vipsImageFormat != VipsImageFormat.GIF);
-        Assume.assumeTrue(vipsImageFormat != VipsImageFormat.AVIF);
         ArrayList<Byte[]> expectedSignatures = SignaturesByExtension.get(vipsImageFormat.getFileExtension());
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer(filename);
         try (VipsImage img = new VipsImage(buffer, buffer.capacity())) {
@@ -576,7 +577,6 @@ public class VipsImageTest {
     public void TestSimplePipelineShouldNotThrow(String filename, VipsImageFormat vipsImageFormat) throws IOException, VipsException {
         // libvips can't save into gif format
         Assume.assumeTrue(vipsImageFormat != VipsImageFormat.GIF);
-        Assume.assumeTrue(vipsImageFormat != VipsImageFormat.AVIF);
         ByteBuffer buffer = VipsTestUtils.getDirectByteBuffer(filename);
         PixelPacket pixel = new PixelPacket(5.0, 255.0, 25.0);
         try (VipsImage img = new VipsImage(buffer, buffer.capacity())) {
@@ -699,7 +699,6 @@ public class VipsImageTest {
         }
     }
 
-    @Ignore
     @Theory
     public void TestWriteAVIFFromByteArrayShouldNotThrows(@FromDataPoints("filenames") String filename,
                                                          boolean lossless)
@@ -715,7 +714,6 @@ public class VipsImageTest {
         }
     }
 
-    @Ignore
     @Test
     public void TestWriteAVIFFromByteArrayShouldShrinkOutputSize()
             throws IOException, VipsException {


### PR DESCRIPTION
I think the problem with heif in the Linux build was that it was built into the `lib64` directory rather than `lib` and not found and included when building libvips.

Also the file header signature seems to be different on macOS, I presume due to different versions of the library?